### PR TITLE
Use 301 for redirects

### DIFF
--- a/src/lilURL.php
+++ b/src/lilURL.php
@@ -61,6 +61,7 @@ class lilURL
         if ($id != '' && $id != basename($_SERVER['PHP_SELF']) && $id != '?login') {
             $location = $this->getURL($id);
             if ($location != false) {
+                header("HTTP/1.1 301 Moved Permanently");
                 header('Location: '.$location);
                 exit();
             }


### PR DESCRIPTION
It sounds like google will index the contents of a 302 (temporary) redirect, but not a 301 (permanent) redirect. Major URL shortners (tinyurl, bitly, goo.gl) all use 301 redirects. Perhaps we should do the same?

This might help prevent search engines like google from indexing the contents of a short URL, but I can't find a definitive source to back up the claim.