### PR TITLE
Update GoURL form

### DIFF
--- a/www/css/go.css
+++ b/www/css/go.css
@@ -190,11 +190,3 @@ table.dataTable tbody th.dt-body-nowrap,table.dataTable tbody td.dt-body-nowrap 
 #dcf-main {
 	background-color: #f6f6f5!important;;
 }
-form#shorten-form {
-	width: 75%;
-}
-@media screen and (max-width: 640px) {
-	form#shorten-form {
-		width: 100%;
-	}
-}

--- a/www/index.php
+++ b/www/index.php
@@ -305,7 +305,7 @@ require(['jquery'], function($) {
         $('#moreOptions').hide();
         $('#showMoreOptions').click(function() {
             var self = this;
-            $('.moreOptions').slideDown('fast', function() {
+            $('#moreOptions').slideDown('fast', function() {
                 $(self).remove();
             });
             return false;

--- a/www/index.php
+++ b/www/index.php
@@ -302,8 +302,8 @@ $page->addHeadLink($lilurl->getBaseUrl(), 'home');
 $page->addScriptDeclaration("
 require(['jquery'], function($) {
     $(function() {
-        $('.moreOptions').hide();
-        $('#moreOptions').click(function() {
+        $('#moreOptions').hide();
+        $('#showMoreOptions').click(function() {
             var self = this;
             $('.moreOptions').slideDown('fast', function() {
                 $(self).remove();

--- a/www/templates/index.php
+++ b/www/templates/index.php
@@ -39,21 +39,21 @@
                 <div class="dcf-form-group">
                     <label id="gaNameLabel" for="gaName">Campaign Name <small class="dcf-required">Required</small></label>
                     <span>
-                        <input id="gaName" name="gaName" type="text" aria-labelledby="gaNameLabel" aria-describedby="gaNameDesc" required>
+                        <input id="gaName" name="gaName" type="text" aria-labelledby="gaNameLabel" aria-describedby="gaNameDesc">
                         <span class="dcf-form-help" id="gaNameDesc" tabindex="-1">Product, promo code or slogan</span>
                     </span>
                 </div>
                 <div class="dcf-form-group">
                     <label id="gaMediumLabel" for="gaMedium">Medium <small class="dcf-required">Required</small></label>
                     <span>
-                        <input id="gaMedium" name="gaMedium" type="text" aria-labelledby="gaMediumLabel" aria-describedby="gaMediumDesc" required>
+                        <input id="gaMedium" name="gaMedium" type="text" aria-labelledby="gaMediumLabel" aria-describedby="gaMediumDesc">
                         <span class="dcf-form-help" id="gaMediumDesc" tabindex="-1">Marketing medium: email, web, banner</span>
                     </span>
                 </div>
                 <div class="dcf-form-group">
                     <label id="gaSourceLabel" for="gaSource">Source <small class="dcf-required">Required</small></label>
                     <span>
-                        <input id="gaSource" name="gaSource" type="text" aria-labelledby="gaSourceLabel" aria-describedby="gaSourceDesc" required>
+                        <input id="gaSource" name="gaSource" type="text" aria-labelledby="gaSourceLabel" aria-describedby="gaSourceDesc">
                         <span class="dcf-form-help" id="gaSourceDesc" tabindex="-1">Referrer: Google, Facebook, Twitter</span>
                     </span>
                 </div>

--- a/www/templates/index.php
+++ b/www/templates/index.php
@@ -17,7 +17,7 @@
                 <legend class="dcf-bold dcf-txt-lg">Custom Alias</legend>
                 <?php if (phpCAS::isAuthenticated()) : ?>
                 <div class="dcf-form-group">
-                    <label id="theAliasLabel" class="dcf-label" for="theAlias">Alias</label>
+                    <label id="theAliasLabel" for="theAlias">Alias</label>
                     <span>
                         <input id="theAlias" name="theAlias" type="text" aria-labelledby="theAliasLabel" aria-describedby="theAliasDesc" disabled>
                         <span class="dcf-form-help" id="theAliasDesc" tabindex="-1">For example, <em>admissions</em> for <i>go.unl.edu/admissions</i> <strong>(letters, numbers, underscores and dashes only)</strong></span>
@@ -25,7 +25,7 @@
                 </div>
                 <?php else: ?>
                 <div class="dcf-form-group">
-                    <label id="theAliasLabel" class="dcf-label" for="theAlias">Alias</label>
+                    <label id="theAliasLabel" for="theAlias">Alias</label>
                     <span>
                         <input id="theAlias" name="theAlias" type="text" aria-labelledby="theAliasLabel" aria-describedby="theAliasDesc" disabled>
                         <span class="dcf-form-help" id="theAliasDesc" tabindex="-1">If you would like to control the <abbr class="dcf-txt-sm" title="Uniform Resource Locator">URL</abbr>, then enter the alias you would like to use. Please <a href="./?login">log in</a> to use this feature.</span>
@@ -37,7 +37,7 @@
                 <legend class="dcf-bold dcf-txt-lg">Google Analytics Campaign Tagging</legend>
                 <p class="dcf-txt-sm">Add your campaign information here and it will be automatically added to your URL when redirected.</p>
                 <div class="dcf-form-group">
-                    <label id="gaNameLabel" for="gaName" class="element">Campaign Name <small class="dcf-required">Required</small></label>
+                    <label id="gaNameLabel" for="gaName">Campaign Name <small class="dcf-required">Required</small></label>
                     <span>
                         <input id="gaName" name="gaName" type="text" aria-labelledby="gaNameLabel" aria-describedby="gaNameDesc" required>
                         <span class="dcf-form-help" id="gaNameDesc" tabindex="-1">Product, promo code or slogan</span>

--- a/www/templates/index.php
+++ b/www/templates/index.php
@@ -19,7 +19,7 @@
                 <div class="dcf-form-group">
                     <label id="theAliasLabel" for="theAlias">Alias</label>
                     <span>
-                        <input id="theAlias" name="theAlias" type="text" aria-labelledby="theAliasLabel" aria-describedby="theAliasDesc" disabled>
+                        <input id="theAlias" name="theAlias" type="text" aria-labelledby="theAliasLabel" aria-describedby="theAliasDesc">
                         <span class="dcf-form-help" id="theAliasDesc" tabindex="-1">For example, <em>admissions</em> for <i>go.unl.edu/admissions</i> <strong>(letters, numbers, underscores and dashes only)</strong></span>
                     </span>
                 </div>

--- a/www/templates/index.php
+++ b/www/templates/index.php
@@ -1,63 +1,78 @@
-<div class="dcf-bleed dcf-pt-8 dcf-pb-8">
-    <div class="dcf-wrapper dcf-txt-center">
-        <form id="shorten-form" class="dcf-input-group-form dcf-d-inline-block dcf-txt-left" action="<?php echo $lilurl->getBaseUrl() ?>" method="post">
-          <ol>
-            <li>
-              <label class="dcf-label" for="theURL"><span class="dcf-required">*</span>Enter the URL that you want to shorten</label>
-              <div class="dcf-input-group">
-                <input class="dcf-input-text" name="theURL" id="theURL" type="text" placeholder="http://www.unl.edu/" value="<?php echo (isset($_POST['theURL']))?htmlentities($_POST['theURL'], ENT_QUOTES):'';?>" />
-                <button class="dcf-btn dcf-btn-primary" type="submit">Shorten</button>
-              </div>
-            </li>
-          </ol>
-          <p><a href="#" id="moreOptions">More Options</a></p>
-          <div class="moreOptions">
+<div class="dcf-bleed dcf-wrapper dcf-pt-8 dcf-pb-8 dcf-d-flex dcf-jc-center">
+    <form class="dcf-form dcf-w-max-lg" id="shorten-form" action="<?php echo $lilurl->getBaseUrl() ?>" method="post">
+        <div class="dcf-form-controls-inline dcf-mb-5">
+            <label for="theURL">Enter the <abbr class="dcf-txt-sm" title="Uniform Resource Locator">URL</abbr> that you want to shorten <small class="dcf-required">Required</small></label>
+            <div class="dcf-input-group">
+              <input id="theURL" name="theURL" type="text" value="<?php echo (isset($_POST['theURL']))?htmlentities($_POST['theURL'], ENT_QUOTES):'';?>" required>
+              <button class="dcf-btn dcf-btn-primary" type="submit">Shorten</button>
+            </div>
+        </div>
+        <button class="dcf-btn dcf-btn-secondary" id="showMoreOptions">Show More Options
+            <svg class="dcf-ml-1 dcf-h-3 dcf-w-3 dcf-fill-current" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24">
+                <path d="M23.9 2.3c-.1-.2-.2-.3-.4-.3H.5c-.2 0-.3.1-.4.3-.1.1-.1.3 0 .5l11.5 19c.1.1.3.2.4.2s.3-.1.4-.2l11.5-19c.1-.2.1-.4 0-.5z"></path>
+            </svg>
+        </button>
+        <div id="moreOptions">
             <fieldset>
-              <legend class="dcf-legend dcf-pt-2 dcf-txt-lg">Custom Alias</legend>
-               <?php if (phpCAS::isAuthenticated()) : ?>
-                 <ol>
-                   <li>
-                     <label class="dcf-label" for="theAlias">Alias <span class="helper">ex: <strong>admissions</strong> for go.unl.edu/admissions <em>(letters/numbers/underscores/dashes only)</em></span></label>
-                     <input class="dcf-input-text" name="theAlias" id="theAlias" type="text" />
-                   </li>
-                 </ol>
-               <?php else: ?>
-                 <ol>
-                   <li>
-                     <label class="dcf-label" for="theAlias">Alias <span class="helper">If you would like to control the URL, then enter the alias you would like to use. Please <a href="./?login">log in</a> to use this feature.</span></label>
-                     <input class="dcf-input-text" name="theAlias" id="theAlias" type="text" disabled="disabled"/>
-                   </li>
-                 </ol>
-               <?php endif; ?>
+                <legend class="dcf-bold dcf-txt-lg">Custom Alias</legend>
+                <?php if (phpCAS::isAuthenticated()) : ?>
+                <div class="dcf-form-group">
+                    <label id="theAliasLabel" class="dcf-label" for="theAlias">Alias</label>
+                    <span>
+                        <input id="theAlias" name="theAlias" type="text" aria-labelledby="theAliasLabel" aria-describedby="theAliasDesc" disabled>
+                        <span class="dcf-form-help" id="theAliasDesc" tabindex="-1">For example, <em>admissions</em> for <i>go.unl.edu/admissions</i> <strong>(letters, numbers, underscores and dashes only)</strong></span>
+                    </span>
+                </div>
+                <?php else: ?>
+                <div class="dcf-form-group">
+                    <label id="theAliasLabel" class="dcf-label" for="theAlias">Alias</label>
+                    <span>
+                        <input id="theAlias" name="theAlias" type="text" aria-labelledby="theAliasLabel" aria-describedby="theAliasDesc" disabled>
+                        <span class="dcf-form-help" id="theAliasDesc" tabindex="-1">If you would like to control the <abbr class="dcf-txt-sm" title="Uniform Resource Locator">URL</abbr>, then enter the alias you would like to use. Please <a href="./?login">log in</a> to use this feature.</span>
+                    </span>
+                </div>
+                <?php endif; ?>
             </fieldset>
             <fieldset>
-              <legend class="dcf-legend dcf-pt-4 dcf-txt-lg">Google Analytics Campaign Tagging</legend>
-              <p class=" dcf-txt-sm">Add your campaign information here and it will be automatically added to your URL when redirected.</p>
-              <ol>
-                <li>
-                  <label class="dcf-label" for="gaName" class="element">Campaign Name<span class="required">*</span> <span class="helper">product, promo code, or slogan</span></label>
-                  <input class="dcf-input-text" name="gaName" id="gaName" type="text" />
-                </li>
-                <li>
-                  <label class="dcf-label" for="gaMedium">Medium<span class="required">*</span> <span class="helper">marketing medium: email, web, banner</span></label>
-                  <input class="dcf-input-text" name="gaMedium" id="gaMedium" type="text" />
-                </li>
-                <li>
-                  <label class="dcf-label" for="gaSource">Source<span class="required">*</span> <span class="helper">referrer: google, facebook, twitter</span></label>
-                  <input class="dcf-input-text" name="gaSource" id="gaSource" type="text" />
-                </li>
-                <li>
-                  <label class="dcf-label" for="gaTerm">Term <span class="helper">identify the keywords</span></label>
-                  <input class="dcf-input-text" name="gaTerm" id="gaTerm" type="text" />
-                </li>
-                <li>
-                  <label class="dcf-label" for="gaContent">Content <span class="helper">use to differentiate ads (A/B testing)</span></label>
-                  <input class="dcf-input-text" name="gaContent" id="gaContent" type="text" />
-                </li>
-              </ol>
+                <legend class="dcf-bold dcf-txt-lg">Google Analytics Campaign Tagging</legend>
+                <p class="dcf-txt-sm">Add your campaign information here and it will be automatically added to your URL when redirected.</p>
+                <div class="dcf-form-group">
+                    <label id="gaNameLabel" for="gaName" class="element">Campaign Name <small class="dcf-required">Required</small></label>
+                    <span>
+                        <input id="gaName" name="gaName" type="text" aria-labelledby="gaNameLabel" aria-describedby="gaNameDesc" required>
+                        <span class="dcf-form-help" id="gaNameDesc" tabindex="-1">Product, promo code or slogan</span>
+                    </span>
+                </div>
+                <div class="dcf-form-group">
+                    <label id="gaMediumLabel" for="gaMedium">Medium <small class="dcf-required">Required</small></label>
+                    <span>
+                        <input id="gaMedium" name="gaMedium" type="text" aria-labelledby="gaMediumLabel" aria-describedby="gaMediumDesc" required>
+                        <span class="dcf-form-help" id="gaMediumDesc" tabindex="-1">Marketing medium: email, web, banner</span>
+                    </span>
+                </div>
+                <div class="dcf-form-group">
+                    <label id="gaSourceLabel" for="gaSource">Source <small class="dcf-required">Required</small></label>
+                    <span>
+                        <input id="gaSource" name="gaSource" type="text" aria-labelledby="gaSourceLabel" aria-describedby="gaSourceDesc" required>
+                        <span class="dcf-form-help" id="gaSourceDesc" tabindex="-1">Referrer: Google, Facebook, Twitter</span>
+                    </span>
+                </div>
+                <div class="dcf-form-group">
+                    <label id="gaTermLabel" for="gaTerm">Term</label>
+                    <span>
+                        <input id="gaTerm" name="gaTerm" type="text" aria-labelledby="gaContentLabel" aria-describedby="gaTermDesc">
+                        <span class="dcf-form-help" id="gaTermDesc" tabindex="-1">Identify the keywords</span>
+                    </span>
+                </div>
+                <div class="dcf-form-group">
+                    <label id="gaContentLabel" for="gaContent">Content</label>
+                    <span>
+                        <input id="gaContent" name="gaContent" type="text" aria-labelledby="gaContentLabel" aria-describedby="gaContentDesc">
+                        <span class="dcf-form-help" id="gaContentDesc" tabindex="-1">Use to differentiate ads (A/B testing)</span>
+                    </span>
+                </div>
             </fieldset>
-            <input class="dcf-mt-6" type="submit" id="submit" name="submit" value="Create URL" />
-          </div>
-        </form>
-    </div>
+            <input class="dcf-mt-6" id="submit" name="submit" type="submit" value="Create URL">
+        </div>
+    </form>
 </div>


### PR DESCRIPTION
- Use four spaces for indents
- Remove ` /` from self-closing tags
- Use `<small>` tag and full text (not just asterisk) to indicate required fields
- Use `<div>`s instead of ordered list items for form groups
- Use DCF utility classes to center and limit width of form
- Remove custom CSS to limit width of form
- Remove DCF form classes no longer needed
- Add `required` attribute to required input fields
- Reorder help text and add `id`s and `aria-describedby` attributes
- Change “More Options” link to a button, add “Show” (verb) and add downward arrow SVG icon
- Update “More Options” `id`s to be more descriptive of action