### PR TITLE
Blocks bots and previews from redirect totals

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -52,8 +52,8 @@ $allowed_domains = array(
     'buros.org',
 );
 
-// Block users agents that contain any of these strings
-$block_user_agents = array(
+// block from counting redirect if client's users agent that contain any of these strings
+$bot_user_agents = array(
     'Googlebot',
     'BingPreview',
     'bingbot',

--- a/config.sample.php
+++ b/config.sample.php
@@ -52,6 +52,27 @@ $allowed_domains = array(
     'buros.org',
 );
 
+// Block users agents that contain any of these strings
+$block_user_agents = array(
+    'Googlebot',
+    'BingPreview',
+    'bingbot',
+    'SemrushBot',
+    'Slurp',
+    'DuckDuckBot',
+    'Baiduspider',
+    'YandexBot',
+    'Spider',
+    'Exabot',
+    'Konqueror',
+    'facebookexternalhit',
+    'facebot',
+    'ia_archiver',
+    'Google Web Preview',
+    'MsnBot',
+    'Twitterbot'
+);
+
 // uncomment the line below to skip the protocol check
 // $allowed_procotols = array();
 

--- a/src/lilURL.php
+++ b/src/lilURL.php
@@ -43,7 +43,7 @@ class lilURL
     const WHERE_UID = 'uid = ' . self::PDO_PLACEHOLDER_UID;
 
     // do not increment redirect if $_SERVER['HTTP_USER_AGENT'] contains anything in this list
-    protected $blocked_user_agents = [];
+    protected $bot_user_agents = [];
 
     protected $db;
     protected static $random_id_length = 4;
@@ -88,10 +88,10 @@ class lilURL
     *
     * @return void
     */
-    public function setBlockedUserAgents($userAgentsToBlock)
+    public function setBotUserAgents($userAgentsToBlock)
     {
         if (count($userAgentsToBlock)) {
-            $this->blocked_user_agents = (array) $userAgentsToBlock;
+            $this->bot_user_agents = (array) $userAgentsToBlock;
         }
         return $this;
     }
@@ -103,7 +103,7 @@ class lilURL
     * @return false if bot not found
     */
     protected function checkForBots(){
-        foreach ($this->blocked_user_agents as $user_agent) {
+        foreach ($this->bot_user_agents as $user_agent) {
             if (isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'], $user_agent) != false) {
                 return true;
             }

--- a/src/lilURL.php
+++ b/src/lilURL.php
@@ -42,6 +42,9 @@ class lilURL
     const WHERE_URL_ID = 'urlID = ' . self::PDO_PLACEHOLDER_URL_ID;
     const WHERE_UID = 'uid = ' . self::PDO_PLACEHOLDER_UID;
 
+    // do not increment redirect if $_SERVER['HTTP_USER_AGENT'] contains anything in this list
+    protected $blocked_user_agents = [];
+
     protected $db;
     protected static $random_id_length = 4;
     protected $allowed_protocols = [];
@@ -78,10 +81,43 @@ class lilURL
         return false;
     }
 
+    /**
+    * Set the list of allowed domains.
+    *
+    * @param array $domains domains to allow
+    *
+    * @return void
+    */
+    public function setBlockedUserAgents($userAgentsToBlock)
+    {
+        if (count($userAgentsToBlock)) {
+            $this->blocked_user_agents = (array) $userAgentsToBlock;
+        }
+        return $this;
+    }
+
+    /**
+    * Checks user agent against list of blocked user agents
+    *
+    * @return true if bot was found
+    * @return false if bot not found
+    */
+    protected function checkForBots(){
+        foreach ($this->blocked_user_agents as $user_agent) {
+            if (isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'], $user_agent) != false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     protected function trackHit($id)
     {
-        // track system redirect
-        $this->incrementRedirectCount($id);
+        if (!$this->checkForBots()) {
+            // track system redirect
+            $this->incrementRedirectCount($id);
+        }
 
         $accountId = $this->getGaAccount();
         if (!$accountId) {

--- a/www/index.php
+++ b/www/index.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../config.inc.php';
 $lilurl = new lilURL(MYSQL_HOST, MYSQL_USER, MYSQL_PASS, MYSQL_DB);
 $lilurl->setAllowedProtocols($allowed_protocols);
 $lilurl->setAllowedDomains($allowed_domains);
-$lilurl->setBlockedUserAgents($block_user_agents);
+$lilurl->setBotUserAgents($bot_user_agents);
 if (defined('GA_ACCOUNT')) {
     $lilurl->setGaAccount(GA_ACCOUNT);
 }

--- a/www/index.php
+++ b/www/index.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../config.inc.php';
 $lilurl = new lilURL(MYSQL_HOST, MYSQL_USER, MYSQL_PASS, MYSQL_DB);
 $lilurl->setAllowedProtocols($allowed_protocols);
 $lilurl->setAllowedDomains($allowed_domains);
+$lilurl->setBlockedUserAgents($block_user_agents);
 if (defined('GA_ACCOUNT')) {
     $lilurl->setGaAccount(GA_ACCOUNT);
 }


### PR DESCRIPTION
Clay notices a high number of redirects for a link, after testing we saw lots of activities from bots and previews which we do not want to count in our redirect totals