### PR TITLE
Fix Auth

### DIFF
--- a/src/goController.php
+++ b/src/goController.php
@@ -44,7 +44,9 @@ class GoController extends GoRouter {
         $this->qrIconSize = $qrIconSize;
         $this->qrCachePrefix = $qrCachePrefix;
         $this->flashBag = $flashBag;
+    }
 
+    private function checkAuth() {
         // See if already logged in via PHP CAS
         if ($this->auth->getAuthType() === $this->auth::AUTH_TYPE_CAS && array_key_exists('unl_sso', $_COOKIE) && !$this->auth->isAuthenticated()) {
             // Run PHPCAS checkAuthentication
@@ -53,8 +55,11 @@ class GoController extends GoRouter {
     }
 
     private function loginCheck() {
-        if ($this->routeRequiresLogin() && !$this->auth->isAuthenticated()) {
-            $this->redirect($this->lilurl->getBaseUrl(self::ROUTE_PATH_LOGIN));
+        if ($this->routeRequiresLogin()) {
+            $this->checkAuth();
+            if (!$this->auth->isAuthenticated()) {
+                $this->redirect($this->lilurl->getBaseUrl(self::ROUTE_PATH_LOGIN));
+            }
         }
     }
 


### PR DESCRIPTION
Auth was checked for redirect routes even though it wasn't needed. This became a problem on mymail.unl.edu, go urls that resolved to images recently started getting into redirect loops where it got stuck trying to log the person in.

This update makes sure the route is not a redirect before checking your auth. So no auth code is ran during redirects.